### PR TITLE
Dist name not right in metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl module Selenium::PageObject
 
 0.011 2014-12-?? TEODESIAN
+    - The distname was getting set as Selenium::PageObject (eg in META.yml),
+      where it should have been Selenium-PageObject.
     - Reformatted this file (Changes) as per CPAN::Changes::Spec
 
 0.010 2014-11-28 TEODESIAN

--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Perl module Selenium::PageObject
     - The distname was getting set as Selenium::PageObject (eg in META.yml),
       where it should have been Selenium-PageObject.
     - Reformatted this file (Changes) as per CPAN::Changes::Spec
+    - Added links to two SEE ALSO entries that didn't have them.
 
 0.010 2014-11-28 TEODESIAN
     - Add test deps for said POD testing

--- a/Changes
+++ b/Changes
@@ -1,9 +1,35 @@
-v0.002 - Added POD
-v0.003 - Corrected POD errors, added tab() method
-v0.004 - use strict/warnings, fixed an issue in the WWW::Selenium bootup code
-v0.005 - RT 98017 - link2gitrepos
-v0.006 - RT 98018 - NAME in pod
-v0.007 - More Kwalitee
-v0.008 - Fix undeclared dep on Data::Random in Selenium::Element
-v0.009 - Fix some incorrect POD discovered with pod testing
-v0.010 - Add test deps for said POD testing
+Revision history for Perl module Selenium::PageObject
+
+0.011 2014-12-?? TEODESIAN
+    - Reformatted this file (Changes) as per CPAN::Changes::Spec
+
+0.010 2014-11-28 TEODESIAN
+    - Add test deps for said POD testing
+
+0.009 2014-11-28 TEODESIAN
+    - Fix some incorrect POD discovered with pod testing
+
+0.008 2014-11-27 TEODESIAN
+    - Fix undeclared dep on Data::Random in Selenium::Element
+
+0.007 2014-08-17 TEODESIAN
+    - More Kwalitee
+
+0.006 2014-08-14 TEODESIAN
+    - RT#98018 - NAME in pod
+
+0.005 2014-08-14 TEODESIAN
+    - RT#98017 - link2gitrepos
+
+0.004 2014-08-14 TEODESIAN
+    - use strict/warnings, fixed an issue in the WWW::Selenium bootup code
+
+0.003 2014-08-14 TEODESIAN
+    - Corrected POD errors, added tab() method
+
+0.002 2014-08-08 TEODESIAN
+    - Added POD
+
+0.001 2014-08-07 TEODESIAN
+    - First release to CPAN
+

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,6 @@ WriteMakefile(
     },
     META_MERGE => {
         'meta-spec' => { version => 2 },
-        name        => 'Selenium::PageObject',
         abstract    => "Perl implementation of selenium PageObjects",
         author      => ['George S. Baugh <teodesian@cpan.org>'],
         resources   => {

--- a/lib/Selenium/PageObject.pm
+++ b/lib/Selenium/PageObject.pm
@@ -160,9 +160,11 @@ L<WWW::Selenium>
 
 L<Selenium::Remote::Driver>
 
-https://code.google.com/p/selenium/wiki/PageFactory for info about PageFactories, like this
+L<https://code.google.com/p/selenium/wiki/PageFactory>
+for info about PageFactories, like this
 
-https://code.google.com/p/selenium/wiki/PageObjects for more info about page objects themselves.
+L<https://code.google.com/p/selenium/wiki/PageObjects>
+for more info about page objects themselves.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
Hi George,

The Makefile.PL for this dist was setting the distname to Selenium::PageObject instead of Selenium-PageObject. This mean that the distname in the metadata didn't match the distname as worked out using CPAN::DistnameInfo (which works it out using the release filename).

I also updated the Changes file to use the most widely used format (defined in CPAN::Changes::Spec).

And there were two URLs in the SEE ALSO section that didn't have L< ... > around them, so they're not appearing as hyperlinks when you look at the doc in MetaCPAN, for example.

Cheers,
Neil
